### PR TITLE
修复next移动端右侧出现空白的问题

### DIFF
--- a/source/css/_common/_core/base.styl
+++ b/source/css/_common/_core/base.styl
@@ -2,6 +2,8 @@ h2, h3, h4, h5, h6 { margin: 60px 0 15px; }
 
 ul { list-style: square; }
 
+a { word-wrap: break-word; }
+
 hr {
   margin: 40px 0;
   height: 3px;


### PR DESCRIPTION
出现空白的原因是如果文章中出现了过长的url，会导致a标签的宽度溢出父元素，撑开整个页面，导致右侧出现空白。

这可能会导致某些手机浏览器拖动代码块时，代码块无法横向滚动，而是整张页面横向滚动的bug
